### PR TITLE
Fix regular expression for core types and add test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 max_line_length = 100
+
+[Makefile]
+indent_style = tab
+indent_size = 8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,9 @@ jobs:
         with:
           version: ${{ matrix.emacs-version }}
       - uses: leotaku/elisp-check@6a1fc6b11ae66dda13859f8b3474a36dfe3ef225
+        with:
+          file: rbs-mode.el
+      - uses: leotaku/elisp-check@6a1fc6b11ae66dda13859f8b3474a36dfe3ef225
+        with:
+          check: ert
+          file: rbs-mode-test.el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next version
 
+- Fix the regular expression for core types.  `StringScanner` is now ignored as a core type rather
+  than `String` plus `Scanner`, for instance.
+
 ## 0.3.1 (2021-04-30)
 
 - Update the incorrect `Version` field.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+check:
+	emacs --batch			\
+		--load ert		\
+		--load rbs-mode-test.el \
+		--funcall ert-run-tests-batch-and-exit
+.PHONY: check

--- a/rbs-mode-test.el
+++ b/rbs-mode-test.el
@@ -1,0 +1,29 @@
+;;; rbs-mode-test --- rbs-mode tests
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(load (concat default-directory "rbs-mode.el"))
+
+(defvar rbs-mode--core-type-regexp)
+
+(ert-deftest string-is-core-type ()
+  (should (string-match rbs-mode--core-type-regexp "String")))
+
+(ert-deftest string-scanner-is-not-core-type ()
+  (should (eql nil (string-match rbs-mode--core-type-regexp "StringScanner"))))
+
+(provide 'rbs-mode-test)
+;;; rbs-mode-test.el ends here.

--- a/rbs-mode.el
+++ b/rbs-mode.el
@@ -209,7 +209,8 @@
         "_ToPath"
         "_ToProc"
         "_ToS"
-        "_ToStr"))))
+        "_ToStr"))
+    word-end))
 
 (defconst rbs-mode--type-definition-regexp
   (rx


### PR DESCRIPTION
Hello,

This updates the regular expression for core types.
It makes, for example, not to recognize `StringScanner` as `String` (core type) and `Scanner`.

Thanks,
